### PR TITLE
Updates wazero to its first beta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,9 @@ require (
 	github.com/ncruces/go-fs v0.2.1
 	github.com/ncruces/go-image v0.1.0
 	github.com/ncruces/jason v0.4.0
-	github.com/ncruces/keyless v0.0.0-20220701091349-958263d1e1ff
 	github.com/ncruces/zenity v0.9.0
 	github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844
-	github.com/tetratelabs/wazero v0.0.0-20220829085532-f2b141ef9c9a
+	github.com/tetratelabs/wazero v1.0.0-beta.1
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/ncruces/go-image v0.1.0 h1:PCbPeiqA2Pbc7m3jWBjhJodwkGew8HEB7fC8SVM+8E
 github.com/ncruces/go-image v0.1.0/go.mod h1:DUnNl2l0T6tEuK266gUGy3Xq8C+A/71XuoWsAHh8bzg=
 github.com/ncruces/jason v0.4.0 h1:0Gy0/YHmy+P2tBNFo31mgzowJuhe35S7jxcEilXIIBI=
 github.com/ncruces/jason v0.4.0/go.mod h1:gaKw0MQbOK/IR2sJ6zBSCOLn+uPOv0iLH4VxOtdkGtU=
-github.com/ncruces/keyless v0.0.0-20220701091349-958263d1e1ff h1:7/ezL9FCZF1G50fjRG3r7rFxOnrbbzZUFzDj7Dll4mY=
-github.com/ncruces/keyless v0.0.0-20220701091349-958263d1e1ff/go.mod h1:MBsmMDae55NRj6StMZFdH2jjj4eCGkQU1wtRmQyIUZI=
 github.com/ncruces/zenity v0.9.0 h1:h2LbKKH4W4CbtBB1t3LxH8PurSpOYXuPBGbLZbBYq14=
 github.com/ncruces/zenity v0.9.0/go.mod h1:KqkrqV3gBDEa6Rrlir2rRWzCvw2dUKe/pMcpE6QCbOA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -51,8 +49,8 @@ github.com/tdewolff/parse/v2 v2.6.2/go.mod h1:woz0cgbLwFdtbjJu8PIKxhW05KplTFQkOd
 github.com/tdewolff/test v1.0.6/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
 github.com/tdewolff/test v1.0.7 h1:8Vs0142DmPFW/bQeHRP3MV19m1gvndjUb1sn8yy74LM=
 github.com/tdewolff/test v1.0.7/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
-github.com/tetratelabs/wazero v0.0.0-20220829085532-f2b141ef9c9a h1:g0WnNGlSBlf5g0O2N6O3OT+Cy1aD+25aeI9bscl2eWw=
-github.com/tetratelabs/wazero v0.0.0-20220829085532-f2b141ef9c9a/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-beta.1 h1:O5DZxiXG0WUUjuq4dwomA5gODRNnzF8LzQ+UOqGY5kY=
+github.com/tetratelabs/wazero v1.0.0-beta.1/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=


### PR DESCRIPTION
This updates to the first beta release of [wazero](https://wazero.io): 1.0.0-beta.1

Future betas will release at the end of each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.
