### PR TITLE
deps: updates wazero to 1.0.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ncruces/go-fs v0.2.1
 	github.com/ncruces/go-image v0.1.0
 	github.com/ncruces/jason v0.4.0
+	github.com/ncruces/keyless v0.0.0-20230223133947-fcba6242c6a3
 	github.com/ncruces/zenity v0.10.6
 	github.com/tetratelabs/wazero v1.0.0-rc.1
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,8 @@ require (
 	github.com/ncruces/go-fs v0.2.1
 	github.com/ncruces/go-image v0.1.0
 	github.com/ncruces/jason v0.4.0
-	github.com/ncruces/keyless v0.0.0-20220701091349-958263d1e1ff
 	github.com/ncruces/zenity v0.10.6
-	github.com/tetratelabs/wazero v1.0.0-pre.9
+	github.com/tetratelabs/wazero v1.0.0-rc.1
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/net v0.7.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/ncruces/go-image v0.1.0 h1:PCbPeiqA2Pbc7m3jWBjhJodwkGew8HEB7fC8SVM+8E
 github.com/ncruces/go-image v0.1.0/go.mod h1:DUnNl2l0T6tEuK266gUGy3Xq8C+A/71XuoWsAHh8bzg=
 github.com/ncruces/jason v0.4.0 h1:0Gy0/YHmy+P2tBNFo31mgzowJuhe35S7jxcEilXIIBI=
 github.com/ncruces/jason v0.4.0/go.mod h1:gaKw0MQbOK/IR2sJ6zBSCOLn+uPOv0iLH4VxOtdkGtU=
+github.com/ncruces/keyless v0.0.0-20230223133947-fcba6242c6a3 h1:jvSzvaXfzO77EwtouvJ+3VhPNdKn2ouZi0wWVjvhyqE=
+github.com/ncruces/keyless v0.0.0-20230223133947-fcba6242c6a3/go.mod h1:Bn19bk/oMEXCIFxgk941V9FzdLVjrcC3xRjYaMCeUBg=
 github.com/ncruces/zenity v0.10.6 h1:lA5SupAxxDSEL4BkaLBkv2LJrh2YxJkbEBxwrF0awXY=
 github.com/ncruces/zenity v0.10.6/go.mod h1:Mp6EUzPkII5A30OSUN/zfEVYOZ3196Fzvq1ba+qyxRk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/ncruces/go-image v0.1.0 h1:PCbPeiqA2Pbc7m3jWBjhJodwkGew8HEB7fC8SVM+8E
 github.com/ncruces/go-image v0.1.0/go.mod h1:DUnNl2l0T6tEuK266gUGy3Xq8C+A/71XuoWsAHh8bzg=
 github.com/ncruces/jason v0.4.0 h1:0Gy0/YHmy+P2tBNFo31mgzowJuhe35S7jxcEilXIIBI=
 github.com/ncruces/jason v0.4.0/go.mod h1:gaKw0MQbOK/IR2sJ6zBSCOLn+uPOv0iLH4VxOtdkGtU=
-github.com/ncruces/keyless v0.0.0-20220701091349-958263d1e1ff h1:7/ezL9FCZF1G50fjRG3r7rFxOnrbbzZUFzDj7Dll4mY=
-github.com/ncruces/keyless v0.0.0-20220701091349-958263d1e1ff/go.mod h1:MBsmMDae55NRj6StMZFdH2jjj4eCGkQU1wtRmQyIUZI=
 github.com/ncruces/zenity v0.10.6 h1:lA5SupAxxDSEL4BkaLBkv2LJrh2YxJkbEBxwrF0awXY=
 github.com/ncruces/zenity v0.10.6/go.mod h1:Mp6EUzPkII5A30OSUN/zfEVYOZ3196Fzvq1ba+qyxRk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -50,8 +48,8 @@ github.com/tdewolff/parse/v2 v2.6.4/go.mod h1:woz0cgbLwFdtbjJu8PIKxhW05KplTFQkOd
 github.com/tdewolff/test v1.0.6/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
 github.com/tdewolff/test v1.0.7 h1:8Vs0142DmPFW/bQeHRP3MV19m1gvndjUb1sn8yy74LM=
 github.com/tdewolff/test v1.0.7/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
-github.com/tetratelabs/wazero v1.0.0-pre.9 h1:2uVdi2bvTi/JQxG2cp3LRm2aRadd3nURn5jcfbvqZcw=
-github.com/tetratelabs/wazero v1.0.0-pre.9/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.0.0-rc.1 h1:ytecMV5Ue0BwezjKh/cM5yv1Mo49ep2R2snSsQUyToc=
+github.com/tetratelabs/wazero v1.0.0-rc.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/dcraw/fs.go
+++ b/pkg/dcraw/fs.go
@@ -85,7 +85,7 @@ func (d *readerDir) IsDir() bool { return true }
 
 func (d *readerDir) ModTime() time.Time { return time.Time{} }
 
-func (d *readerDir) Mode() fs.FileMode { return 0700 }
+func (d *readerDir) Mode() fs.FileMode { return fs.ModeDir | 0700 }
 
 func (d *readerDir) Name() string { return "." }
 


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-rc.1](https://github.com/tetratelabs/wazero/releases/tag/1.0.0-rc.1). This version does not change any public API, but it delivers several bug fixes and improvements; including
* Full support to the WASI test suite and other third-party integration tests
* Fix for an issue with the context cancellation API
* A number of optimizations to reduce compilation overhead

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
